### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749200714,
+        "narHash": "sha256-W8KiJIrVwmf43JOPbbTu5lzq+cmdtRqaNbOsZigjioY=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "dotfiles": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748333587,
+        "narHash": "sha256-A1kQ66ks8enBmD97Jw8nO5FFSVG0YEWeJL12cD7GRrI=",
+        "owner": "SilverKnightKMA",
+        "repo": "dotfiles-flake",
+        "rev": "bb12d5078515242e09be2254fe94c87355ac968f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SilverKnightKMA",
+        "repo": "dotfiles-flake",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749358668,
+        "narHash": "sha256-V91nN4Q9ZwX0N+Gzu+F8SnvzMcdURYnMcIvpfLQzD5M=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "06451df423dd5e555f39857438ffc16c5b765862",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixos-facter-modules": {
+      "locked": {
+        "lastModified": 1743671943,
+        "narHash": "sha256-7sYig0+RcrR3sOL5M+2spbpFUHyEP7cnUvCaqFOBjyU=",
+        "owner": "numtide",
+        "repo": "nixos-facter-modules",
+        "rev": "58ad9691670d293a15221d4a78818e0088d2e086",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nixos-facter-modules",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "disko": "disko",
+        "dotfiles": "dotfiles",
+        "home-manager": "home-manager",
+        "nixos-facter-modules": "nixos-facter-modules",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Added input 'disko':
    'github:nix-community/disko/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6?narHash=sha256-W8KiJIrVwmf43JOPbbTu5lzq%2BcmdtRqaNbOsZigjioY%3D' (2025-06-06)
• Added input 'disko/nixpkgs':
    follows 'nixpkgs'
• Added input 'dotfiles':
    'github:SilverKnightKMA/dotfiles-flake/bb12d5078515242e09be2254fe94c87355ac968f?narHash=sha256-A1kQ66ks8enBmD97Jw8nO5FFSVG0YEWeJL12cD7GRrI%3D' (2025-05-27)
• Added input 'home-manager':
    'github:nix-community/home-manager/06451df423dd5e555f39857438ffc16c5b765862?narHash=sha256-V91nN4Q9ZwX0N%2BGzu%2BF8SnvzMcdURYnMcIvpfLQzD5M%3D' (2025-06-08)
• Added input 'home-manager/nixpkgs':
    follows 'nixpkgs'
• Added input 'nixos-facter-modules':
    'github:numtide/nixos-facter-modules/58ad9691670d293a15221d4a78818e0088d2e086?narHash=sha256-7sYig0%2BRcrR3sOL5M%2B2spbpFUHyEP7cnUvCaqFOBjyU%3D' (2025-04-03)
• Added input 'nixpkgs':
    'github:nixos/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d?narHash=sha256-QuUtALJpVrPnPeozlUG/y%2BoIMSLdptHxb3GK6cpSVhA%3D' (2025-06-05)

```

</p></details>

 - Added input [`nixos-facter-modules`](https://github.com/numtide/nixos-facter-modules): [github.com/numtide/nixos-facter-modules](https://github.com/numtide/nixos-facter-modules/tree/58ad9691670d293a15221d4a78818e0088d2e086/)
 - Added input [`disko`](https://github.com/nix-community/disko): [github.com/nix-community/disko](https://github.com/nix-community/disko/tree/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6/)
 - Added input `home-manager/nixpkgs`: ``
 - Added input `disko/nixpkgs`: ``
 - Added input [`nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/d3d2d80a2191a73d1e86456a751b83aa13085d7d/)
 - Added input [`home-manager`](https://github.com/nix-community/home-manager): [github.com/nix-community/home-manager](https://github.com/nix-community/home-manager/tree/06451df423dd5e555f39857438ffc16c5b765862/)
 - Added input [`dotfiles`](https://github.com/SilverKnightKMA/dotfiles-flake): [github.com/SilverKnightKMA/dotfiles-flake](https://github.com/SilverKnightKMA/dotfiles-flake/tree/bb12d5078515242e09be2254fe94c87355ac968f/)