### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -1,7 +1,7 @@
 name: Auto Merge Approved PR
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -1,5 +1,9 @@
 name: Auto Merge Approved PR
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_review:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/4](https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow is automerging pull requests, it needs `contents: read` to access repository contents and `pull-requests: write` to merge pull requests. These permissions will be explicitly defined to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
