### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,6 +7,7 @@ on:
 name: Code analysis
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   deadnix:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 * * *' # runs daily at 00:00
 
 name: Code analysis
+permissions:
+  contents: read
 
 jobs:
   deadnix:


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/3](https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs code analysis tasks, it likely only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
