### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *' # runs daily at 00:00
 
+permissions:
+  contents: read
+
 jobs:
   nix-flake-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/2](https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs read-only operations (e.g., checking out the repository and running a flake checker), we will set `contents: read` as the minimal required permission. This ensures that the workflow has the least privileges necessary to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
