### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,6 +2,9 @@
 
 # https://github.com/sandhose/nixconf/blob/055de30/.github/workflows/update.yaml
 name: Update
+permissions:
+  contents: write
+  pull-requests: write
 on:
   # Manual triggering
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/1](https://github.com/SilverKnightKMA/nix-cfg/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations:
1. The `contents: write` permission is needed for the `nix flake update --commit-lock-file` step, which modifies the repository's lock file.
2. The `pull-requests: write` permission is required for the `peter-evans/create-pull-request` action to create and manage pull requests.
3. All other permissions will be set to `read` or omitted entirely.

The `permissions` block will be added at the root of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
