### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749200714,
-        "narHash": "sha256-W8KiJIrVwmf43JOPbbTu5lzq+cmdtRqaNbOsZigjioY=",
+        "lastModified": 1749436314,
+        "narHash": "sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6",
+        "rev": "dfa4d1b9c39c0342ef133795127a3af14598017a",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749358668,
-        "narHash": "sha256-V91nN4Q9ZwX0N+Gzu+F8SnvzMcdURYnMcIvpfLQzD5M=",
+        "lastModified": 1749944797,
+        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "06451df423dd5e555f39857438ffc16c5b765862",
+        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6?narHash=sha256-W8KiJIrVwmf43JOPbbTu5lzq%2BcmdtRqaNbOsZigjioY%3D' (2025-06-06)
  → 'github:nix-community/disko/dfa4d1b9c39c0342ef133795127a3af14598017a?narHash=sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w%3D' (2025-06-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/06451df423dd5e555f39857438ffc16c5b765862?narHash=sha256-V91nN4Q9ZwX0N%2BGzu%2BF8SnvzMcdURYnMcIvpfLQzD5M%3D' (2025-06-08)
  → 'github:nix-community/home-manager/c5f345153397f62170c18ded1ae1f0875201d49a?narHash=sha256-1l6ZW%2B2%2BLDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk%3D' (2025-06-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d?narHash=sha256-QuUtALJpVrPnPeozlUG/y%2BoIMSLdptHxb3GK6cpSVhA%3D' (2025-06-05)
  → 'github:nixos/nixpkgs/ee930f9755f58096ac6e8ca94a1887e0534e2d81?narHash=sha256-Kh9K4taXbVuaLC0IL%2B9HcfvxsSUx8dPB5s5weJcc9pc%3D' (2025-06-13)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`17d08c65` ➡️ `dfa4d1b9`](https://github.com/nix-community/disko/compare/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6...dfa4d1b9c39c0342ef133795127a3af14598017a) <sub>(2025-06-06 to 2025-06-09)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d3d2d80a` ➡️ `ee930f97`](https://github.com/nixos/nixpkgs/compare/d3d2d80a2191a73d1e86456a751b83aa13085d7d...ee930f9755f58096ac6e8ca94a1887e0534e2d81) <sub>(2025-06-05 to 2025-06-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`06451df4` ➡️ `c5f34515`](https://github.com/nix-community/home-manager/compare/06451df423dd5e555f39857438ffc16c5b765862...c5f345153397f62170c18ded1ae1f0875201d49a) <sub>(2025-06-08 to 2025-06-14)</sub>