### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749436314,
-        "narHash": "sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w=",
+        "lastModified": 1750903843,
+        "narHash": "sha256-Ng9+f0H5/dW+mq/XOKvB9uwvGbsuiiO6HrPdAcVglCs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "dfa4d1b9c39c0342ef133795127a3af14598017a",
+        "rev": "83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749944797,
-        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
+        "lastModified": 1751309344,
+        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
+        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1743671943,
-        "narHash": "sha256-7sYig0+RcrR3sOL5M+2spbpFUHyEP7cnUvCaqFOBjyU=",
+        "lastModified": 1750412875,
+        "narHash": "sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "58ad9691670d293a15221d4a78818e0088d2e086",
+        "rev": "14df13c84552a7d1f33c1cd18336128fbc43f920",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749794982,
-        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/dfa4d1b9c39c0342ef133795127a3af14598017a?narHash=sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w%3D' (2025-06-09)
  → 'github:nix-community/disko/83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae?narHash=sha256-Ng9%2Bf0H5/dW%2Bmq/XOKvB9uwvGbsuiiO6HrPdAcVglCs%3D' (2025-06-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c5f345153397f62170c18ded1ae1f0875201d49a?narHash=sha256-1l6ZW%2B2%2BLDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk%3D' (2025-06-14)
  → 'github:nix-community/home-manager/78fc50f1cf8e57a974ff4bfe654563fce43d6289?narHash=sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk%3D' (2025-06-30)
• Updated input 'nixos-facter-modules':
    'github:numtide/nixos-facter-modules/58ad9691670d293a15221d4a78818e0088d2e086?narHash=sha256-7sYig0%2BRcrR3sOL5M%2B2spbpFUHyEP7cnUvCaqFOBjyU%3D' (2025-04-03)
  → 'github:numtide/nixos-facter-modules/14df13c84552a7d1f33c1cd18336128fbc43f920?narHash=sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc%3D' (2025-06-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ee930f9755f58096ac6e8ca94a1887e0534e2d81?narHash=sha256-Kh9K4taXbVuaLC0IL%2B9HcfvxsSUx8dPB5s5weJcc9pc%3D' (2025-06-13)
  → 'github:nixos/nixpkgs/3016b4b15d13f3089db8a41ef937b13a9e33a8df?narHash=sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU%2Btt4YY%3D' (2025-06-30)

```

</p></details>

 - Updated input [`nixos-facter-modules`](https://github.com/numtide/nixos-facter-modules): [`58ad9691` ➡️ `14df13c8`](https://github.com/numtide/nixos-facter-modules/compare/58ad9691670d293a15221d4a78818e0088d2e086...14df13c84552a7d1f33c1cd18336128fbc43f920) <sub>(2025-04-03 to 2025-06-20)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`dfa4d1b9` ➡️ `83c4da29`](https://github.com/nix-community/disko/compare/dfa4d1b9c39c0342ef133795127a3af14598017a...83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae) <sub>(2025-06-09 to 2025-06-26)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ee930f97` ➡️ `3016b4b1`](https://github.com/nixos/nixpkgs/compare/ee930f9755f58096ac6e8ca94a1887e0534e2d81...3016b4b15d13f3089db8a41ef937b13a9e33a8df) <sub>(2025-06-13 to 2025-06-30)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c5f34515` ➡️ `78fc50f1`](https://github.com/nix-community/home-manager/compare/c5f345153397f62170c18ded1ae1f0875201d49a...78fc50f1cf8e57a974ff4bfe654563fce43d6289) <sub>(2025-06-14 to 2025-06-30)</sub>