### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750903843,
-        "narHash": "sha256-Ng9+f0H5/dW+mq/XOKvB9uwvGbsuiiO6HrPdAcVglCs=",
+        "lastModified": 1752541678,
+        "narHash": "sha256-dyhGzkld6jPqnT/UfGV2oqe7tYn7hppAqFvF3GZTyXY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae",
+        "rev": "2bf3421f7fed5c84d9392b62dcb9d76ef09796a7",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751309344,
-        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
+        "lastModified": 1752467539,
+        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
+        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae?narHash=sha256-Ng9%2Bf0H5/dW%2Bmq/XOKvB9uwvGbsuiiO6HrPdAcVglCs%3D' (2025-06-26)
  → 'github:nix-community/disko/2bf3421f7fed5c84d9392b62dcb9d76ef09796a7?narHash=sha256-dyhGzkld6jPqnT/UfGV2oqe7tYn7hppAqFvF3GZTyXY%3D' (2025-07-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/78fc50f1cf8e57a974ff4bfe654563fce43d6289?narHash=sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk%3D' (2025-06-30)
  → 'github:nix-community/home-manager/1e54837569e0b80797c47be4720fab19e0db1616?narHash=sha256-4kaR%2Bxmng9YPASckfvIgl5flF/1nAZOplM%2BWp9I5SMI%3D' (2025-07-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3016b4b15d13f3089db8a41ef937b13a9e33a8df?narHash=sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU%2Btt4YY%3D' (2025-06-30)
  → 'github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0?narHash=sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X%2BxgOL0%3D' (2025-07-08)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`83c4da29` ➡️ `2bf3421f`](https://github.com/nix-community/disko/compare/83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae...2bf3421f7fed5c84d9392b62dcb9d76ef09796a7) <sub>(2025-06-26 to 2025-07-15)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3016b4b1` ➡️ `9807714d`](https://github.com/nixos/nixpkgs/compare/3016b4b15d13f3089db8a41ef937b13a9e33a8df...9807714d6944a957c2e036f84b0ff8caf9930bc0) <sub>(2025-06-30 to 2025-07-08)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`78fc50f1` ➡️ `1e548375`](https://github.com/nix-community/home-manager/compare/78fc50f1cf8e57a974ff4bfe654563fce43d6289...1e54837569e0b80797c47be4720fab19e0db1616) <sub>(2025-06-30 to 2025-07-14)</sub>