### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752541678,
-        "narHash": "sha256-dyhGzkld6jPqnT/UfGV2oqe7tYn7hppAqFvF3GZTyXY=",
+        "lastModified": 1753140376,
+        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2bf3421f7fed5c84d9392b62dcb9d76ef09796a7",
+        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752467539,
-        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
+        "lastModified": 1753983724,
+        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/2bf3421f7fed5c84d9392b62dcb9d76ef09796a7?narHash=sha256-dyhGzkld6jPqnT/UfGV2oqe7tYn7hppAqFvF3GZTyXY%3D' (2025-07-15)
  → 'github:nix-community/disko/545aba02960caa78a31bd9a8709a0ad4b6320a5c?narHash=sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb%2BmYCodI5uuB8%3D' (2025-07-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1e54837569e0b80797c47be4720fab19e0db1616?narHash=sha256-4kaR%2Bxmng9YPASckfvIgl5flF/1nAZOplM%2BWp9I5SMI%3D' (2025-07-14)
  → 'github:nix-community/home-manager/7035020a507ed616e2b20c61491ae3eaa8e5462c?narHash=sha256-2vlAOJv4lBrE%2BP1uOGhZ1symyjXTRdn/mz0tZ6faQcg%3D' (2025-07-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0?narHash=sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X%2BxgOL0%3D' (2025-07-08)
  → 'github:nixos/nixpkgs/dc9637876d0dcc8c9e5e22986b857632effeb727?narHash=sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM%3D' (2025-07-28)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`2bf3421f` ➡️ `545aba02`](https://github.com/nix-community/disko/compare/2bf3421f7fed5c84d9392b62dcb9d76ef09796a7...545aba02960caa78a31bd9a8709a0ad4b6320a5c) <sub>(2025-07-15 to 2025-07-21)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9807714d` ➡️ `dc963787`](https://github.com/nixos/nixpkgs/compare/9807714d6944a957c2e036f84b0ff8caf9930bc0...dc9637876d0dcc8c9e5e22986b857632effeb727) <sub>(2025-07-08 to 2025-07-28)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1e548375` ➡️ `7035020a`](https://github.com/nix-community/home-manager/compare/1e54837569e0b80797c47be4720fab19e0db1616...7035020a507ed616e2b20c61491ae3eaa8e5462c) <sub>(2025-07-14 to 2025-07-31)</sub>