### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753140376,
-        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
+        "lastModified": 1754971456,
+        "narHash": "sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
+        "rev": "8246829f2e675a46919718f9a64b71afe3bfb22d",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753983724,
-        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
+        "lastModified": 1755121891,
+        "narHash": "sha256-UtYkukiGnPRJ5rpd4W/wFVrLMh8fqtNkqHTPgHEtrqU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
+        "rev": "279ca5addcdcfa31ac852b3ecb39fc372684f426",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1750412875,
-        "narHash": "sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc=",
+        "lastModified": 1755092700,
+        "narHash": "sha256-knQiR+/3d9RQR6rIDUORO6ZBITleDKDqS4r/pl327WU=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "14df13c84552a7d1f33c1cd18336128fbc43f920",
+        "rev": "7641b72e58c59ebb3c753fc36ff8ee3506ae8e05",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1755027561,
+        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/545aba02960caa78a31bd9a8709a0ad4b6320a5c?narHash=sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb%2BmYCodI5uuB8%3D' (2025-07-21)
  → 'github:nix-community/disko/8246829f2e675a46919718f9a64b71afe3bfb22d?narHash=sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0%3D' (2025-08-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7035020a507ed616e2b20c61491ae3eaa8e5462c?narHash=sha256-2vlAOJv4lBrE%2BP1uOGhZ1symyjXTRdn/mz0tZ6faQcg%3D' (2025-07-31)
  → 'github:nix-community/home-manager/279ca5addcdcfa31ac852b3ecb39fc372684f426?narHash=sha256-UtYkukiGnPRJ5rpd4W/wFVrLMh8fqtNkqHTPgHEtrqU%3D' (2025-08-13)
• Updated input 'nixos-facter-modules':
    'github:numtide/nixos-facter-modules/14df13c84552a7d1f33c1cd18336128fbc43f920?narHash=sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc%3D' (2025-06-20)
  → 'github:numtide/nixos-facter-modules/7641b72e58c59ebb3c753fc36ff8ee3506ae8e05?narHash=sha256-knQiR%2B/3d9RQR6rIDUORO6ZBITleDKDqS4r/pl327WU%3D' (2025-08-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/dc9637876d0dcc8c9e5e22986b857632effeb727?narHash=sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM%3D' (2025-07-28)
  → 'github:nixos/nixpkgs/005433b926e16227259a1843015b5b2b7f7d1fc3?narHash=sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV%2B3/aO28gXpGtMXI%3D' (2025-08-12)

```

</p></details>

 - Updated input [`nixos-facter-modules`](https://github.com/numtide/nixos-facter-modules): [`14df13c8` ➡️ `7641b72e`](https://github.com/numtide/nixos-facter-modules/compare/14df13c84552a7d1f33c1cd18336128fbc43f920...7641b72e58c59ebb3c753fc36ff8ee3506ae8e05) <sub>(2025-06-20 to 2025-08-13)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`545aba02` ➡️ `8246829f`](https://github.com/nix-community/disko/compare/545aba02960caa78a31bd9a8709a0ad4b6320a5c...8246829f2e675a46919718f9a64b71afe3bfb22d) <sub>(2025-07-21 to 2025-08-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`dc963787` ➡️ `005433b9`](https://github.com/nixos/nixpkgs/compare/dc9637876d0dcc8c9e5e22986b857632effeb727...005433b926e16227259a1843015b5b2b7f7d1fc3) <sub>(2025-07-28 to 2025-08-12)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`7035020a` ➡️ `279ca5ad`](https://github.com/nix-community/home-manager/compare/7035020a507ed616e2b20c61491ae3eaa8e5462c...279ca5addcdcfa31ac852b3ecb39fc372684f426) <sub>(2025-07-31 to 2025-08-13)</sub>