### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754971456,
-        "narHash": "sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0=",
+        "lastModified": 1756115622,
+        "narHash": "sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8246829f2e675a46919718f9a64b71afe3bfb22d",
+        "rev": "bafad29f89e83b2d861b493aa23034ea16595560",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755121891,
-        "narHash": "sha256-UtYkukiGnPRJ5rpd4W/wFVrLMh8fqtNkqHTPgHEtrqU=",
+        "lastModified": 1756683562,
+        "narHash": "sha256-3fcIqwm1u+rF3kkgUYYEIcLrs93+Pi+a6AwiEAxdP5g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "279ca5addcdcfa31ac852b3ecb39fc372684f426",
+        "rev": "fccb44df77266a3891939f35197f538dace3442f",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1755092700,
-        "narHash": "sha256-knQiR+/3d9RQR6rIDUORO6ZBITleDKDqS4r/pl327WU=",
+        "lastModified": 1756491981,
+        "narHash": "sha256-lXyDAWPw/UngVtQfgQ8/nrubs2r+waGEYIba5UX62+k=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "7641b72e58c59ebb3c753fc36ff8ee3506ae8e05",
+        "rev": "c1b29520945d3e148cd96618c8a0d1f850965d8c",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755027561,
-        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/8246829f2e675a46919718f9a64b71afe3bfb22d?narHash=sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0%3D' (2025-08-12)
  → 'github:nix-community/disko/bafad29f89e83b2d861b493aa23034ea16595560?narHash=sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM%3D' (2025-08-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/279ca5addcdcfa31ac852b3ecb39fc372684f426?narHash=sha256-UtYkukiGnPRJ5rpd4W/wFVrLMh8fqtNkqHTPgHEtrqU%3D' (2025-08-13)
  → 'github:nix-community/home-manager/fccb44df77266a3891939f35197f538dace3442f?narHash=sha256-3fcIqwm1u%2BrF3kkgUYYEIcLrs93%2BPi%2Ba6AwiEAxdP5g%3D' (2025-08-31)
• Updated input 'nixos-facter-modules':
    'github:numtide/nixos-facter-modules/7641b72e58c59ebb3c753fc36ff8ee3506ae8e05?narHash=sha256-knQiR%2B/3d9RQR6rIDUORO6ZBITleDKDqS4r/pl327WU%3D' (2025-08-13)
  → 'github:numtide/nixos-facter-modules/c1b29520945d3e148cd96618c8a0d1f850965d8c?narHash=sha256-lXyDAWPw/UngVtQfgQ8/nrubs2r%2BwaGEYIba5UX62%2Bk%3D' (2025-08-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/005433b926e16227259a1843015b5b2b7f7d1fc3?narHash=sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV%2B3/aO28gXpGtMXI%3D' (2025-08-12)
  → 'github:nixos/nixpkgs/d7600c775f877cd87b4f5a831c28aa94137377aa?narHash=sha256-tlOn88coG5fzdyqz6R93SQL5Gpq%2Bm/DsWpekNFhqPQk%3D' (2025-08-30)

```

</p></details>

 - Updated input [`nixos-facter-modules`](https://github.com/numtide/nixos-facter-modules): [`7641b72e` ➡️ `c1b29520`](https://github.com/numtide/nixos-facter-modules/compare/7641b72e58c59ebb3c753fc36ff8ee3506ae8e05...c1b29520945d3e148cd96618c8a0d1f850965d8c) <sub>(2025-08-13 to 2025-08-29)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`8246829f` ➡️ `bafad29f`](https://github.com/nix-community/disko/compare/8246829f2e675a46919718f9a64b71afe3bfb22d...bafad29f89e83b2d861b493aa23034ea16595560) <sub>(2025-08-12 to 2025-08-25)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`005433b9` ➡️ `d7600c77`](https://github.com/nixos/nixpkgs/compare/005433b926e16227259a1843015b5b2b7f7d1fc3...d7600c775f877cd87b4f5a831c28aa94137377aa) <sub>(2025-08-12 to 2025-08-30)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`279ca5ad` ➡️ `fccb44df`](https://github.com/nix-community/home-manager/compare/279ca5addcdcfa31ac852b3ecb39fc372684f426...fccb44df77266a3891939f35197f538dace3442f) <sub>(2025-08-13 to 2025-08-31)</sub>