### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769524058,
-        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
+        "lastModified": 1771881364,
+        "narHash": "sha256-A5uE/hMium5of/QGC6JwF5TGoDAfpNtW00T0s9u/PN8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
+        "rev": "a4cb7bf73f264d40560ba527f9280469f1f081c6",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771102945,
-        "narHash": "sha256-e5NfW8NhC3qChR8bHVni/asrig/ZFzd1wzpq+cEE/tg=",
+        "lastModified": 1772330507,
+        "narHash": "sha256-hAn6dxDVwhEagJUw8RWrkmjvnlSViVEWQxHnCdki/eg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ff5e5d882c51f9a032479595cbab40fd04f56399",
+        "rev": "6656349da84134f284069a30763893d83336a0dc",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/71a3fc97d80881e91710fe721f1158d3b96ae14d?narHash=sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE%3D' (2026-01-27)
  → 'github:nix-community/disko/a4cb7bf73f264d40560ba527f9280469f1f081c6?narHash=sha256-A5uE/hMium5of/QGC6JwF5TGoDAfpNtW00T0s9u/PN8%3D' (2026-02-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ff5e5d882c51f9a032479595cbab40fd04f56399?narHash=sha256-e5NfW8NhC3qChR8bHVni/asrig/ZFzd1wzpq%2BcEE/tg%3D' (2026-02-14)
  → 'github:nix-community/home-manager/6656349da84134f284069a30763893d83336a0dc?narHash=sha256-hAn6dxDVwhEagJUw8RWrkmjvnlSViVEWQxHnCdki/eg%3D' (2026-03-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa?narHash=sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb%2BZnAo5RzSxJg%3D' (2026-02-13)
  → 'github:nixos/nixpkgs/dd9b079222d43e1943b6ebd802f04fd959dc8e61?narHash=sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE%3D' (2026-02-27)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`71a3fc97` ➡️ `a4cb7bf7`](https://github.com/nix-community/disko/compare/71a3fc97d80881e91710fe721f1158d3b96ae14d...a4cb7bf73f264d40560ba527f9280469f1f081c6) <sub>(2026-01-27 to 2026-02-23)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a82ccc39` ➡️ `dd9b0792`](https://github.com/nixos/nixpkgs/compare/a82ccc39b39b621151d6732718e3e250109076fa...dd9b079222d43e1943b6ebd802f04fd959dc8e61) <sub>(2026-02-13 to 2026-02-27)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`ff5e5d88` ➡️ `6656349d`](https://github.com/nix-community/home-manager/compare/ff5e5d882c51f9a032479595cbab40fd04f56399...6656349da84134f284069a30763893d83336a0dc) <sub>(2026-02-14 to 2026-03-01)</sub>