### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771881364,
-        "narHash": "sha256-A5uE/hMium5of/QGC6JwF5TGoDAfpNtW00T0s9u/PN8=",
+        "lastModified": 1773506317,
+        "narHash": "sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a4cb7bf73f264d40560ba527f9280469f1f081c6",
+        "rev": "878ec37d6a8f52c6c801d0e2a2ad554c75b9353c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772330507,
-        "narHash": "sha256-hAn6dxDVwhEagJUw8RWrkmjvnlSViVEWQxHnCdki/eg=",
+        "lastModified": 1773422513,
+        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6656349da84134f284069a30763893d83336a0dc",
+        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a4cb7bf73f264d40560ba527f9280469f1f081c6?narHash=sha256-A5uE/hMium5of/QGC6JwF5TGoDAfpNtW00T0s9u/PN8%3D' (2026-02-23)
  → 'github:nix-community/disko/878ec37d6a8f52c6c801d0e2a2ad554c75b9353c?narHash=sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0%3D' (2026-03-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6656349da84134f284069a30763893d83336a0dc?narHash=sha256-hAn6dxDVwhEagJUw8RWrkmjvnlSViVEWQxHnCdki/eg%3D' (2026-03-01)
  → 'github:nix-community/home-manager/ef12a9a2b0f77c8fa3dda1e7e494fca668909056?narHash=sha256-MPjR48roW7CUMU6lu0%2BqQGqj92Kuh3paIulMWFZy%2BNQ%3D' (2026-03-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/dd9b079222d43e1943b6ebd802f04fd959dc8e61?narHash=sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE%3D' (2026-02-27)
  → 'github:nixos/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda?narHash=sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk%3D' (2026-03-13)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`a4cb7bf7` ➡️ `878ec37d`](https://github.com/nix-community/disko/compare/a4cb7bf73f264d40560ba527f9280469f1f081c6...878ec37d6a8f52c6c801d0e2a2ad554c75b9353c) <sub>(2026-02-23 to 2026-03-14)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`dd9b0792` ➡️ `c06b4ae3`](https://github.com/nixos/nixpkgs/compare/dd9b079222d43e1943b6ebd802f04fd959dc8e61...c06b4ae3d6599a672a6210b7021d699c351eebda) <sub>(2026-02-27 to 2026-03-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`6656349d` ➡️ `ef12a9a2`](https://github.com/nix-community/home-manager/compare/6656349da84134f284069a30763893d83336a0dc...ef12a9a2b0f77c8fa3dda1e7e494fca668909056) <sub>(2026-03-01 to 2026-03-13)</sub>