### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773506317,
-        "narHash": "sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0=",
+        "lastModified": 1773889306,
+        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "878ec37d6a8f52c6c801d0e2a2ad554c75b9353c",
+        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773422513,
-        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
+        "lastModified": 1774991950,
+        "narHash": "sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
+        "rev": "f2d3e04e278422c7379e067e323734f3e8c585a7",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1766558141,
-        "narHash": "sha256-Ud9v49ZPsoDBFuyJSQ2Mpw1ZgAH/aMwUwwzrVoetNus=",
+        "lastModified": 1773858690,
+        "narHash": "sha256-oW0/lC0oRG5H5LaK6Rmh9L1wmkn9TbenM4bXwnIEDKA=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "e796d536e3d83de74267069e179dc620a608ed7d",
+        "rev": "139dcef4dfc97009629c445806f197883351ab4a",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/878ec37d6a8f52c6c801d0e2a2ad554c75b9353c?narHash=sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0%3D' (2026-03-14)
  → 'github:nix-community/disko/5ad85c82cc52264f4beddc934ba57f3789f28347?narHash=sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw%3D' (2026-03-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ef12a9a2b0f77c8fa3dda1e7e494fca668909056?narHash=sha256-MPjR48roW7CUMU6lu0%2BqQGqj92Kuh3paIulMWFZy%2BNQ%3D' (2026-03-13)
  → 'github:nix-community/home-manager/f2d3e04e278422c7379e067e323734f3e8c585a7?narHash=sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw%3D' (2026-03-31)
• Updated input 'nixos-facter-modules':
    'github:numtide/nixos-facter-modules/e796d536e3d83de74267069e179dc620a608ed7d?narHash=sha256-Ud9v49ZPsoDBFuyJSQ2Mpw1ZgAH/aMwUwwzrVoetNus%3D' (2025-12-24)
  → 'github:numtide/nixos-facter-modules/139dcef4dfc97009629c445806f197883351ab4a?narHash=sha256-oW0/lC0oRG5H5LaK6Rmh9L1wmkn9TbenM4bXwnIEDKA%3D' (2026-03-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda?narHash=sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk%3D' (2026-03-13)
  → 'github:nixos/nixpkgs/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685?narHash=sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg%3D' (2026-03-28)

```

</p></details>

 - Updated input [`nixos-facter-modules`](https://github.com/numtide/nixos-facter-modules): [`e796d536` ➡️ `139dcef4`](https://github.com/numtide/nixos-facter-modules/compare/e796d536e3d83de74267069e179dc620a608ed7d...139dcef4dfc97009629c445806f197883351ab4a) <sub>(2025-12-24 to 2026-03-18)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`878ec37d` ➡️ `5ad85c82`](https://github.com/nix-community/disko/compare/878ec37d6a8f52c6c801d0e2a2ad554c75b9353c...5ad85c82cc52264f4beddc934ba57f3789f28347) <sub>(2026-03-14 to 2026-03-19)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c06b4ae3` ➡️ `8110df5a`](https://github.com/nixos/nixpkgs/compare/c06b4ae3d6599a672a6210b7021d699c351eebda...8110df5ad7abf5d4c0f6fb0f8f978390e77f9685) <sub>(2026-03-13 to 2026-03-28)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`ef12a9a2` ➡️ `f2d3e04e`](https://github.com/nix-community/home-manager/compare/ef12a9a2b0f77c8fa3dda1e7e494fca668909056...f2d3e04e278422c7379e067e323734f3e8c585a7) <sub>(2026-03-13 to 2026-03-31)</sub>