### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774991950,
-        "narHash": "sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw=",
+        "lastModified": 1776184304,
+        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2d3e04e278422c7379e067e323734f3e8c585a7",
+        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f2d3e04e278422c7379e067e323734f3e8c585a7?narHash=sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw%3D' (2026-03-31)
  → 'github:nix-community/home-manager/3c7524c68348ef79ce48308e0978611a050089b2?narHash=sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc%3D' (2026-04-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685?narHash=sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg%3D' (2026-03-28)
  → 'github:nixos/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa?narHash=sha256-ar3rofg%2BawPB8QXDaFJhJ2jJhu%2BKqN/PRCXeyuXR76E%3D' (2026-04-09)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`8110df5a` ➡️ `4c1018da`](https://github.com/nixos/nixpkgs/compare/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685...4c1018dae018162ec878d42fec712642d214fdfa) <sub>(2026-03-28 to 2026-04-09)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`f2d3e04e` ➡️ `3c7524c6`](https://github.com/nix-community/home-manager/compare/f2d3e04e278422c7379e067e323734f3e8c585a7...3c7524c68348ef79ce48308e0978611a050089b2) <sub>(2026-03-31 to 2026-04-14)</sub>