### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773889306,
-        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1777594677,
+        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/5ad85c82cc52264f4beddc934ba57f3789f28347?narHash=sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw%3D' (2026-03-19)
  → 'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3c7524c68348ef79ce48308e0978611a050089b2?narHash=sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc%3D' (2026-04-14)
  → 'github:nix-community/home-manager/899c08a15beae5da51a5cecd6b2b994777a948da?narHash=sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI%3D' (2026-05-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa?narHash=sha256-ar3rofg%2BawPB8QXDaFJhJ2jJhu%2BKqN/PRCXeyuXR76E%3D' (2026-04-09)
  → 'github:nixos/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76?narHash=sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M%2BC8yzzIRYbE%3D' (2026-04-27)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`5ad85c82` ➡️ `32f4236b`](https://github.com/nix-community/disko/compare/5ad85c82cc52264f4beddc934ba57f3789f28347...32f4236bfc141ae930b5ba2fb604f561fed5219d) <sub>(2026-03-19 to 2026-04-19)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4c1018da` ➡️ `1c3fe55a`](https://github.com/nixos/nixpkgs/compare/4c1018dae018162ec878d42fec712642d214fdfa...1c3fe55ad329cbcb28471bb30f05c9827f724c76) <sub>(2026-04-09 to 2026-04-27)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`3c7524c6` ➡️ `899c08a1`](https://github.com/nix-community/home-manager/compare/3c7524c68348ef79ce48308e0978611a050089b2...899c08a15beae5da51a5cecd6b2b994777a948da) <sub>(2026-04-14 to 2026-05-01)</sub>