### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777594677,
-        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
+        "lastModified": 1778805320,
+        "narHash": "sha256-nGFJ01m2CTBKD4ABtcY4vLhHrRN91LKr/pn41PcU78A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
+        "rev": "9846abe15e7d0d36b8acbd4d05f2b87461744c92",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
  → 'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/899c08a15beae5da51a5cecd6b2b994777a948da?narHash=sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI%3D' (2026-05-01)
  → 'github:nix-community/home-manager/9846abe15e7d0d36b8acbd4d05f2b87461744c92?narHash=sha256-nGFJ01m2CTBKD4ABtcY4vLhHrRN91LKr/pn41PcU78A%3D' (2026-05-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76?narHash=sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M%2BC8yzzIRYbE%3D' (2026-04-27)
  → 'github:nixos/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32?narHash=sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA%3D' (2026-05-10)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`32f4236b` ➡️ `63b4e7e6`](https://github.com/nix-community/disko/compare/32f4236bfc141ae930b5ba2fb604f561fed5219d...63b4e7e6cf75307c1d26ac3762b886b5b0247267) <sub>(2026-04-19 to 2026-05-02)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1c3fe55a` ➡️ `da5ad661`](https://github.com/nixos/nixpkgs/compare/1c3fe55ad329cbcb28471bb30f05c9827f724c76...da5ad661ba4e5ef59ba743f0d112cbc30e474f32) <sub>(2026-04-27 to 2026-05-10)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`899c08a1` ➡️ `9846abe1`](https://github.com/nix-community/home-manager/compare/899c08a15beae5da51a5cecd6b2b994777a948da...9846abe15e7d0d36b8acbd4d05f2b87461744c92) <sub>(2026-05-01 to 2026-05-15)</sub>