### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1780048612,
+        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778805320,
-        "narHash": "sha256-nGFJ01m2CTBKD4ABtcY4vLhHrRN91LKr/pn41PcU78A=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9846abe15e7d0d36b8acbd4d05f2b87461744c92",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
  → 'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/9846abe15e7d0d36b8acbd4d05f2b87461744c92?narHash=sha256-nGFJ01m2CTBKD4ABtcY4vLhHrRN91LKr/pn41PcU78A%3D' (2026-05-15)
  → 'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32?narHash=sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA%3D' (2026-05-10)
  → 'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`63b4e7e6` ➡️ `caa775cf`](https://github.com/nix-community/disko/compare/63b4e7e6cf75307c1d26ac3762b886b5b0247267...caa775cf67bfdc47f940edd96c975b5016df9059) <sub>(2026-05-02 to 2026-05-29)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`da5ad661` ➡️ `64c08a7c`](https://github.com/nixos/nixpkgs/compare/da5ad661ba4e5ef59ba743f0d112cbc30e474f32...64c08a7ca051951c8eae34e3e3cb1e202fe36786) <sub>(2026-05-10 to 2026-05-23)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`9846abe1` ➡️ `7d8127d3`](https://github.com/nix-community/home-manager/compare/9846abe15e7d0d36b8acbd4d05f2b87461744c92...7d8127d308c3fb9664f7e643eec944be74ebb37d) <sub>(2026-05-15 to 2026-05-30)</sub>