### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780048612,
-        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1781477932,
+        "narHash": "sha256-7EZqIpytCiWoVsUQIRytWr2H0esy2xuntQHjG4Hb/48=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
  → 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1?narHash=sha256-RxWs5ND31KzTG7wvMM%2BPMfUjyNpmIEr999lqNARaM5o%3D' (2026-06-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
  → 'github:nix-community/home-manager/ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5?narHash=sha256-7EZqIpytCiWoVsUQIRytWr2H0esy2xuntQHjG4Hb/48%3D' (2026-06-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:nixos/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`caa775cf` ➡️ `ff8702b4`](https://github.com/nix-community/disko/compare/caa775cf67bfdc47f940edd96c975b5016df9059...ff8702b4de27f72b4c78573dfb89ec74e36abdf1) <sub>(2026-05-29 to 2026-06-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`64c08a7c` ➡️ `9ae611a4`](https://github.com/nixos/nixpkgs/compare/64c08a7ca051951c8eae34e3e3cb1e202fe36786...9ae611a455b90cf061d8f332b977e387bda8e1ca) <sub>(2026-05-23 to 2026-06-10)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`7d8127d3` ➡️ `ed8263e7`](https://github.com/nix-community/home-manager/compare/7d8127d308c3fb9664f7e643eec944be74ebb37d...ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5) <sub>(2026-05-30 to 2026-06-14)</sub>