### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781477932,
-        "narHash": "sha256-7EZqIpytCiWoVsUQIRytWr2H0esy2xuntQHjG4Hb/48=",
+        "lastModified": 1782839684,
+        "narHash": "sha256-vzs4SBgPsK4aNzlJR2PpFwtARazXMOxZonQnDz0YHxk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5",
+        "rev": "2a37d71bbe69e1522ddabf03a4cea0374958bdbe",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5?narHash=sha256-7EZqIpytCiWoVsUQIRytWr2H0esy2xuntQHjG4Hb/48%3D' (2026-06-14)
  → 'github:nix-community/home-manager/2a37d71bbe69e1522ddabf03a4cea0374958bdbe?narHash=sha256-vzs4SBgPsK4aNzlJR2PpFwtARazXMOxZonQnDz0YHxk%3D' (2026-06-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
  → 'github:nixos/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8?narHash=sha256-oPXCU/SSUokcGaJREHibG1CBX3%2Bs/W7orDWQOZDsEeQ%3D' (2026-06-29)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9ae611a4` ➡️ `b5aa0fbd`](https://github.com/nixos/nixpkgs/compare/9ae611a455b90cf061d8f332b977e387bda8e1ca...b5aa0fbd538984f6e3d201be0005b4463d8b09f8) <sub>(2026-06-10 to 2026-06-29)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`ed8263e7` ➡️ `2a37d71b`](https://github.com/nix-community/home-manager/compare/ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5...2a37d71bbe69e1522ddabf03a4cea0374958bdbe) <sub>(2026-06-14 to 2026-06-30)</sub>